### PR TITLE
Add missing log functions

### DIFF
--- a/src/red4ext.dll/Config.hpp
+++ b/src/red4ext.dll/Config.hpp
@@ -22,7 +22,7 @@ public:
         void LoadV0(const toml::value& aConfig);
 
         spdlog::level::level_enum level = spdlog::level::info;
-        spdlog::level::level_enum flushOn = spdlog::level::err;
+        spdlog::level::level_enum flushOn = spdlog::level::info;
         uint32_t maxFiles = 5;
         uint32_t maxFileSize = 10;
     };

--- a/src/red4ext.dll/v0/Plugin.cpp
+++ b/src/red4ext.dll/v0/Plugin.cpp
@@ -24,8 +24,11 @@ v0::Plugin::Plugin(const std::filesystem::path& aPath, wil::unique_hmodule aModu
     m_logger.TraceWF = v0::Logger::TraceWF;
     m_logger.Debug = v0::Logger::Debug;
     m_logger.DebugF = v0::Logger::DebugF;
+    m_logger.DebugW = v0::Logger::DebugW;
     m_logger.DebugWF = v0::Logger::DebugWF;
+    m_logger.Info = v0::Logger::Info;
     m_logger.InfoF = v0::Logger::InfoF;
+    m_logger.InfoW = v0::Logger::InfoW;
     m_logger.InfoWF = v0::Logger::InfoWF;
     m_logger.Warn = v0::Logger::Warn;
     m_logger.WarnF = v0::Logger::WarnF;


### PR DESCRIPTION
Couple logger functions were missing .)

Proposition: to set default flush level to info, OR let plugins to set desired flush level via call. To ease modders and end-users support, especially when something crashes.  Wdyt?