### PR TITLE
v1.13.0 Hotfix

### DIFF
--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -21,10 +21,10 @@ bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& 
         return Global_ExecuteProcess(a1, aCommand, aArgs, aCurrentDirectory, a5);
     }
 
-    auto scriptCompilationSystem = App::Get()->GetScriptCompilationSystem();
+    auto str = App::Get()->GetScriptCompilationSystem()->GetCompilationArgs(aArgs);
     
     FixedWString newArgs;
-    newArgs.str = scriptCompilationSystem->GetCompilationArgs(aArgs).c_str();
+    newArgs.str = str.c_str();
     newArgs.length = newArgs.maxLength = wcslen(newArgs.str);
     return Global_ExecuteProcess(a1, aCommand, newArgs, aCurrentDirectory, a5);
 }

--- a/src/dll/Systems/ScriptCompilationSystem.cpp
+++ b/src/dll/Systems/ScriptCompilationSystem.cpp
@@ -90,10 +90,10 @@ std::wstring ScriptCompilationSystem::GetCompilationArgs(const FixedWString& aOr
     for (const auto& [plugin, path] : m_scriptPaths)
     {
         spdlog::info(L"{}: '{}'", plugin->GetName(), path);
-        pathsFile << path << std::endl;
+        pathsFile << path.wstring() << std::endl;
     }
     spdlog::info(L"Paths written to: '{}'", pathsFilePath);
-    format_to(std::back_inserter(buffer), LR"( -compilePathsFile "{}"\0)", pathsFilePath);
+    format_to(std::back_inserter(buffer), LR"( -compilePathsFile "{}"{})", pathsFilePath, '\0');
     spdlog::info(L"Final redscript compilation arg string: '{}'", buffer.data());
     return buffer.data();
 }


### PR DESCRIPTION
* Correctly null terminate buffer
* Don't escape paths in `redscript_paths.txt`
* Ensure wstring lasts long enough