### PR TITLE
Redscript Compilation Error-checking

### DIFF
--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -3,30 +3,62 @@
 #include "App.hpp"
 #include "Hook.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
+#include <winbase.h>
 
 namespace
 {
 bool isAttached = false;
 
-bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
-                            RED4ext::CString& aCurrentDirectory, char a5);
+bool _Global_ExecuteProcess(ScriptCompilation* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
+                            RED4ext::CString& aCurrentDirectory, ExecuteProcess_Flags aFlags);
 Hook<decltype(&_Global_ExecuteProcess)> Global_ExecuteProcess(Addresses::Global_ExecuteProcess,
                                                               &_Global_ExecuteProcess);
 
-bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
-                            RED4ext::CString& aCurrentDirectory, char a5)
+bool _Global_ExecuteProcess(ScriptCompilation* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
+                            RED4ext::CString& aCurrentDirectory, ExecuteProcess_Flags aFlags)
 {
     if (strstr(aCommand.c_str(), "scc.exe") == nullptr)
     {
-        return Global_ExecuteProcess(a1, aCommand, aArgs, aCurrentDirectory, a5);
+        return Global_ExecuteProcess(a1, aCommand, aArgs, aCurrentDirectory, aFlags);
     }
 
     auto str = App::Get()->GetScriptCompilationSystem()->GetCompilationArgs(aArgs);
-    
+
     FixedWString newArgs;
     newArgs.str = str.c_str();
     newArgs.length = newArgs.maxLength = wcslen(newArgs.str);
-    return Global_ExecuteProcess(a1, aCommand, newArgs, aCurrentDirectory, a5);
+
+    spdlog::info(L"Final redscript compilation arg string: '{}'", newArgs.str);
+    auto result = Global_ExecuteProcess(a1, aCommand, newArgs, aCurrentDirectory, aFlags);
+
+    // 60000 is used in the game
+    auto waitResult = WaitForSingleObject(a1->handle, 60000);
+    switch (waitResult) {
+        case WAIT_TIMEOUT:
+            spdlog::error("Redscript compilation timed-out - exiting");
+            SHOW_LAST_ERROR_MESSAGE_AND_EXIT_FILE_LINE("Redscript compilation timed-out");
+            break;
+        case WAIT_ABANDONED:
+            spdlog::error("Redscript compilation was abandoned - exiting");
+            SHOW_LAST_ERROR_MESSAGE_AND_EXIT_FILE_LINE("Redscript compilation was abandoned");
+            break;
+        case WAIT_FAILED:
+            spdlog::error("Redscript compilation failed - exiting");
+            SHOW_LAST_ERROR_MESSAGE_AND_EXIT_FILE_LINE("Redscript compilation failed");
+            break;
+    }
+
+    GetExitCodeProcess(a1->handle, &a1->errorCode);
+
+    if (a1->errorCode) {
+        spdlog::error(L"Redscript compilation was unsuccessful with error code: {} - exiting", a1->errorCode);
+        // redscript already showed the error, so we can just exit
+        TerminateProcess(GetCurrentProcess(), 1);
+    } else {
+        spdlog::info(L"Redscript compilation executed successfully");
+    }
+
+    return result;
 }
 } // namespace
 

--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -21,10 +21,10 @@ bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& 
         return Global_ExecuteProcess(a1, aCommand, aArgs, aCurrentDirectory, a5);
     }
 
-    auto scriptCompilationSystem = App::Get()->GetScriptCompilationSystem();
+    auto str = App::Get()->GetScriptCompilationSystem()->GetCompilationArgs(aArgs);
     
     FixedWString newArgs;
-    newArgs.str = scriptCompilationSystem->GetCompilationArgs(aArgs).c_str();
+    newArgs.str = str.c_str();
     newArgs.length = newArgs.maxLength = wcslen(newArgs.str);
     return Global_ExecuteProcess(a1, aCommand, newArgs, aCurrentDirectory, a5);
 }

--- a/src/dll/Systems/ScriptCompilationSystem.cpp
+++ b/src/dll/Systems/ScriptCompilationSystem.cpp
@@ -90,10 +90,10 @@ std::wstring ScriptCompilationSystem::GetCompilationArgs(const FixedWString& aOr
     for (const auto& [plugin, path] : m_scriptPaths)
     {
         spdlog::info(L"{}: '{}'", plugin->GetName(), path);
-        pathsFile << path << std::endl;
+        pathsFile << path.wstring() << std::endl;
     }
     spdlog::info(L"Paths written to: '{}'", pathsFilePath);
-    format_to(std::back_inserter(buffer), LR"( -compilePathsFile "{}"\0)", pathsFilePath);
+    format_to(std::back_inserter(buffer), LR"( -compilePathsFile "{}"{})", pathsFilePath, '\0');
     spdlog::info(L"Final redscript compilation arg string: '{}'", buffer.data());
     return buffer.data();
 }

--- a/src/dll/Systems/ScriptCompilationSystem.cpp
+++ b/src/dll/Systems/ScriptCompilationSystem.cpp
@@ -94,6 +94,5 @@ std::wstring ScriptCompilationSystem::GetCompilationArgs(const FixedWString& aOr
     }
     spdlog::info(L"Paths written to: '{}'", pathsFilePath);
     format_to(std::back_inserter(buffer), LR"( -compilePathsFile "{}"{})", pathsFilePath, '\0');
-    spdlog::info(L"Final redscript compilation arg string: '{}'", buffer.data());
     return buffer.data();
 }

--- a/src/dll/Systems/ScriptCompilationSystem.hpp
+++ b/src/dll/Systems/ScriptCompilationSystem.hpp
@@ -12,6 +12,31 @@ struct FixedWString
     const wchar_t* str;
 };
 
+// aFlags is initially 0
+enum class ExecuteProcess_Flags : unsigned char
+{
+    // unsets CREATE_NO_WINDOW
+    ShouldCreateWindow = 0x1,
+    // sets CREATE_BREAKAWAY_FROM_JOB | CREATE_SUSPENDED in Process Creation Flags
+    BreakawayAndSuspend = 0x2,
+    Unk3 = 0x3,
+    // unsets bInheritHandles
+    NoInheritHandles = 0x4,
+};
+
+DEFINE_ENUM_FLAG_OPERATORS(ExecuteProcess_Flags)
+
+struct ScriptCompilation
+{
+  wchar_t command[4096];
+  PHANDLE readPipe;
+  PHANDLE writePipe;
+  HANDLE handle;
+  HANDLE hThread;
+  uint64_t unk2;
+  DWORD errorCode;
+};
+
 class ScriptCompilationSystem : public ISystem
 {
 public:


### PR DESCRIPTION
Prints the status of the redscript compilation & exits if the command fails (assume game will not run if our redscript files were not compiled) - we might want to also show an error, but redscript will have already shown one. Also handles the error results for `WaitForSingleObject`, but I was not able to trigger these conditions to test.

Based on #22 