### PR TITLE
fix: use .native instead of .string

### DIFF
--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -31,7 +31,7 @@ bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& 
         return ExecuteScc(scc);
     }
 
-    spdlog::info("Could not load the scc library from '{}', falling back to the CLI", sccLib.string());
+    spdlog::info(L"Could not load the scc library from '{}', falling back to the CLI", sccLib.native());
 
     auto str = App::Get()->GetScriptCompilationSystem()->GetCompilationArgs(aArgs);
 


### PR DESCRIPTION
based on this conversation: https://github.com/WopsS/RED4ext/pull/37#discussion_r1431239212 with @WSSDude