### PR TITLE
feat: notify user about incompatible plugins in error popup

### DIFF
--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -4,7 +4,6 @@
 #include "Hook.hpp"
 #include "RED4ext/Scripting/ScriptReport.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
-#include <codecvt>
 
 namespace
 {

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -40,7 +40,7 @@ bool _ScriptValidator_Validate(uint64_t self, uint64_t a1, RED4ext::ScriptReport
     const auto message = WritePopupMessage(validationErrors, incompatiblePlugins);
     if (!message.empty())
     {
-        SHOW_MESSAGE_BOX_AND_EXIT_FILE_LINE("{}", message);
+        SHOW_MESSAGE_BOX_AND_EXIT_FILE_LINE(L"{}", message);
     }
 
     return result;

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -93,18 +93,7 @@ bool Hooks::ValidateScripts::Detach()
 std::string WritePopupMessage(const std::vector<ValidationError>& validationErrors,
                               const std::vector<PluginSystem::PluginName>& incompatiblePlugins)
 {
-    std::unordered_set<std::string_view> faultyScriptFiles;
-
-    for (const auto& error : validationErrors)
-    {
-        auto ref = error.GetSourceRef();
-        if (ref)
-        {
-            faultyScriptFiles.insert(ref->file);
-        }
-    }
-
-    if (incompatiblePlugins.empty() && faultyScriptFiles.empty())
+    if (validationErrors.empty())
     {
         return {};
     }
@@ -122,6 +111,17 @@ std::string WritePopupMessage(const std::vector<ValidationError>& validationErro
             fmt::format_to(std::back_inserter(message), L"- {}\n", plugin);
         }
         fmt::format_to(std::back_inserter(message), "\n");
+    }
+
+    std::unordered_set<std::string_view> faultyScriptFiles;
+
+    for (const auto& error : validationErrors)
+    {
+        auto ref = error.GetSourceRef();
+        if (ref)
+        {
+            faultyScriptFiles.insert(ref->file);
+        }
     }
 
     if (!faultyScriptFiles.empty())

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -131,11 +131,9 @@ std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErr
                        L"The following scripts contain invalid native definitions and will prevent "
                        L"your game from starting:\n");
 
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         for (const auto& file : faultyScriptFiles)
         {
-            const auto fileWide = converter.from_bytes(std::string(file));
-            fmt::format_to(std::back_inserter(message), L"- {}\n", fileWide);
+            fmt::format_to(std::back_inserter(message), L"- {}\n", Utils::Widen(file));
         }
         fmt::format_to(std::back_inserter(message), L"\n");
     }

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -102,15 +102,14 @@ std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErr
 
     if (!incompatiblePlugins.empty())
     {
-        fmt::format_to(std::back_inserter(message),
-                       L"The following RED4ext plugins could not be loaded because they are "
-                       L"incompatible with the current version of the game:\n");
+        fmt::format_to(message, L"The following RED4ext plugins could not be loaded because they are "
+                                L"incompatible with the current version of the game:\n");
 
         for (const auto& plugin : incompatiblePlugins)
         {
-            fmt::format_to(std::back_inserter(message), L"- {}\n", plugin);
+            fmt::format_to(message, L"- {}\n", plugin);
         }
-        fmt::format_to(std::back_inserter(message), L"\n");
+        fmt::format_to(message, L"\n");
     }
 
     std::unordered_set<std::string_view> faultyScriptFiles;
@@ -126,22 +125,20 @@ std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErr
 
     if (!faultyScriptFiles.empty())
     {
-        fmt::format_to(std::back_inserter(message),
-                       L"The following scripts contain invalid native definitions and will prevent "
-                       L"your game from starting:\n");
+        fmt::format_to(message, L"The following scripts contain invalid native definitions and will prevent "
+                                L"your game from starting:\n");
 
         for (const auto& file : faultyScriptFiles)
         {
-            fmt::format_to(std::back_inserter(message), L"- {}\n", Utils::Widen(file));
+            fmt::format_to(message, L"- {}\n", Utils::Widen(file));
         }
-        fmt::format_to(std::back_inserter(message), L"\n");
+        fmt::format_to(message, L"\n");
     }
 
-    fmt::format_to(std::back_inserter(message),
-                   L"Check if these mods are up-to-date and installed correctly. If you keep seeing "
-                   L"this message after updating/re-installing them, you might have to remove them "
-                   L"in order to play the game.\n"
-                   L"More details can be found in the logs.\n");
+    fmt::format_to(message, L"Check if these mods are up-to-date and installed correctly. If you keep seeing "
+                            L"this message after updating/re-installing them, you might have to remove them "
+                            L"in order to play the game.\n"
+                            L"More details can be found in the logs.\n");
 
     return std::wstring(message.data(), message.size());
 }

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -40,7 +40,7 @@ bool _ScriptValidator_Validate(uint64_t self, uint64_t a1, RED4ext::ScriptReport
     const auto message = WritePopupMessage(validationErrors, incompatiblePlugins);
     if (!message.empty())
     {
-        MessageBoxW(0, message.c_str(), L"Script Validation Error", MB_OK | MB_ICONERROR);
+        SHOW_MESSAGE_BOX_AND_EXIT_FILE_LINE("{}", message);
     }
 
     return result;
@@ -98,12 +98,12 @@ std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErr
         return {};
     }
 
-    std::wstring message;
+    fmt::wmemory_buffer message;
 
     if (!incompatiblePlugins.empty())
     {
         fmt::format_to(std::back_inserter(message),
-                       L"The following red4ext plugins could not be loaded because they are "
+                       L"The following RED4ext plugins could not be loaded because they are "
                        L"incompatible with the current version of the game:\n");
 
         for (const auto& plugin : incompatiblePlugins)
@@ -141,7 +141,7 @@ std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErr
                    L"Check if these mods are up-to-date and installed correctly. If you keep seeing "
                    L"this message after updating/re-installing them, you might have to remove them "
                    L"in order to play the game.\n"
-                   L"More details can be found in the red4ext logs.\n");
+                   L"More details can be found in the logs.\n");
 
-    return message;
+    return std::wstring(message.data(), message.size());
 }

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -2,9 +2,8 @@
 #include "Addresses.hpp"
 #include "App.hpp"
 #include "Hook.hpp"
-#include "Systems/ScriptCompilationSystem.hpp"
 #include "RED4ext/Scripting/ScriptReport.hpp"
-#include "ScriptValidationError.hpp"
+#include "Systems/ScriptCompilationSystem.hpp"
 
 namespace
 {
@@ -37,7 +36,8 @@ bool _ScriptValidator_Validate(uint64_t self, uint64_t a1, RED4ext::ScriptReport
         }
     }
 
-    auto message = WritePopupMessage(errors);
+    auto& incompatiblePlugins = App::Get()->GetPluginSystem()->GetIncompatiblePlugins();
+    auto message = WritePopupMessage(errors, incompatiblePlugins);
     if (!message.empty())
     {
         MessageBoxA(0, message.c_str(), "Script Validation Error", MB_OK | MB_ICONERROR);
@@ -88,4 +88,59 @@ bool Hooks::ValidateScripts::Detach()
 
     isAttached = result != NO_ERROR;
     return !isAttached;
+}
+
+std::string WritePopupMessage(const std::vector<ValidationError>& validationErrors,
+                              const std::vector<PluginSystem::PluginName>& incompatiblePlugins)
+{
+    std::unordered_set<std::string_view> faultyScriptFiles;
+
+    for (const auto& error : validationErrors)
+    {
+        auto ref = error.GetSourceRef();
+        if (ref)
+        {
+            faultyScriptFiles.insert(ref->file);
+        }
+    }
+
+    if (incompatiblePlugins.empty() && faultyScriptFiles.empty())
+    {
+        return {};
+    }
+
+    std::string message;
+
+    if (!incompatiblePlugins.empty())
+    {
+        fmt::format_to(std::back_inserter(message),
+                       "The following red4ext plugins could not be loaded because they are "
+                       "incompatible with the current version of the game:\n");
+
+        for (const auto& plugin : incompatiblePlugins)
+        {
+            fmt::format_to(std::back_inserter(message), L"- {}\n", plugin);
+        }
+        fmt::format_to(std::back_inserter(message), "\n");
+    }
+
+    if (!faultyScriptFiles.empty())
+    {
+        fmt::format_to(std::back_inserter(message),
+                       "The following scripts contain invalid native definitions and will prevent "
+                       "your game from starting:\n");
+        for (const auto& file : faultyScriptFiles)
+        {
+            fmt::format_to(std::back_inserter(message), "- {}\n", file);
+        }
+        fmt::format_to(std::back_inserter(message), "\n");
+    }
+
+    fmt::format_to(std::back_inserter(message),
+                   "Check if these mods are up-to-date and installed correctly. If you keep seeing "
+                   "this message after updating/re-installing them, you might have to remove them "
+                   "in order to play the game.\n"
+                   "More details can be found in the red4ext logs.\n");
+
+    return message;
 }

--- a/src/dll/Hooks/ValidateScripts.hpp
+++ b/src/dll/Hooks/ValidateScripts.hpp
@@ -8,5 +8,5 @@ bool Attach();
 bool Detach();
 } // namespace Hooks::ValidateScripts
 
-std::string WritePopupMessage(const std::vector<ValidationError>& validationErrors,
-                              const std::vector<PluginSystem::PluginName>& incompatiblePlugins);
+std::wstring WritePopupMessage(const std::vector<ValidationError>& validationErrors,
+                               const std::vector<PluginSystem::PluginName>& incompatiblePlugins);

--- a/src/dll/Hooks/ValidateScripts.hpp
+++ b/src/dll/Hooks/ValidateScripts.hpp
@@ -1,7 +1,12 @@
 #pragma once
+#include "ScriptValidationError.hpp"
+#include "Systems/PluginSystem.hpp"
 
 namespace Hooks::ValidateScripts
 {
 bool Attach();
 bool Detach();
 } // namespace Hooks::ValidateScripts
+
+std::string WritePopupMessage(const std::vector<ValidationError>& validationErrors,
+                              const std::vector<PluginSystem::PluginName>& incompatiblePlugins);

--- a/src/dll/ScriptValidationError.cpp
+++ b/src/dll/ScriptValidationError.cpp
@@ -77,35 +77,3 @@ std::optional<SourceRef> ValidationError::GetSourceRef() const
         return {};
     }
 }
-
-std::string WritePopupMessage(const std::vector<ValidationError>& errors)
-{
-    std::unordered_set<std::string_view> faultyFiles;
-
-    for (const auto& error : errors)
-    {
-        auto ref = error.GetSourceRef();
-        if (ref)
-        {
-            faultyFiles.insert(ref->file);
-        }
-    }
-
-    if (faultyFiles.empty())
-    {
-        return "";
-    }
-
-    std::string message =
-        "The scripts below contain invalid native definitions and will prevent your game from starting:\n";
-    for (const auto& file : faultyFiles)
-    {
-        fmt::format_to(std::back_inserter(message), "- {}\n", file);
-    }
-    fmt::format_to(std::back_inserter(message),
-                   "\n"
-                   "Check for updates of the mods that added these files and if you still see this "
-                   "message after updating them, they'll have to be uninstalled.\n"
-                   "More details about the errors can be found in the logs.\n");
-    return message;
-}

--- a/src/dll/ScriptValidationError.hpp
+++ b/src/dll/ScriptValidationError.hpp
@@ -22,5 +22,3 @@ struct ValidationError
     static ValidationError FromString(const char* str);
     std::optional<SourceRef> GetSourceRef() const;
 };
-
-std::string WritePopupMessage(const std::vector<ValidationError>& errors);

--- a/src/dll/Systems/PluginSystem.cpp
+++ b/src/dll/Systems/PluginSystem.cpp
@@ -167,6 +167,11 @@ std::shared_ptr<PluginBase> PluginSystem::GetPlugin(HMODULE aModule) const
     return nullptr;
 }
 
+const std::vector<PluginSystem::PluginName>& PluginSystem::GetIncompatiblePlugins() const
+{
+    return m_incompatiblePlugins;
+}
+
 void PluginSystem::Load(const std::filesystem::path& aPath, bool aUseAlteredSearchPath)
 {
     spdlog::info(L"Loading plugin from '{}'...", aPath);
@@ -233,7 +238,8 @@ void PluginSystem::Load(const std::filesystem::path& aPath, bool aUseAlteredSear
             spdlog::warn(L"{} (version: {}) is incompatible with the current patch ({}). This version of the plugin "
                          L"was compiled for patch {}",
                          pluginName, std::to_wstring(pluginVersion), currentPatch, requestedPatch);
-
+            
+            m_incompatiblePlugins.emplace_back(pluginName);
             return;
         }
     }

--- a/src/dll/Systems/PluginSystem.hpp
+++ b/src/dll/Systems/PluginSystem.hpp
@@ -8,6 +8,8 @@
 class PluginSystem : public ISystem
 {
 public:
+    using PluginName = std::wstring;
+
     PluginSystem(const Config::PluginsConfig& aConfig, const Paths& aPaths);
     ~PluginSystem() = default;
 
@@ -17,6 +19,7 @@ public:
     void Shutdown() final;
 
     std::shared_ptr<PluginBase> GetPlugin(HMODULE aModule) const;
+    const std::vector<PluginName>& GetIncompatiblePlugins() const;
 
 private:
     using Map_t = std::unordered_map<HMODULE, std::shared_ptr<PluginBase>>;
@@ -31,4 +34,5 @@ private:
     const Paths& m_paths;
 
     Map_t m_plugins;
+    std::vector<PluginName> m_incompatiblePlugins;
 };


### PR DESCRIPTION
pretty simple change that adds incompatible plugin information to the error message

looks like this when both the DLL and scripts fail to load
![Screenshot 2023-12-19 220253](https://github.com/WopsS/RED4ext/assets/11986158/cb28494a-a02e-46a2-bc74-07d1605c1ee0)


looks like this when just scripts fail to load
![Screenshot 2023-12-19 220501](https://github.com/WopsS/RED4ext/assets/11986158/2a3f950b-cd56-497b-8982-1360ca9debf4)


we don't show the popup when there are no validation errors, because incompatible plugins on their own aren't necessarily a problem
