### PR TITLE
feat: write modded redscripts to a separate file

### DIFF
--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -95,7 +95,7 @@ bool ExecuteScc(SccApi& scc)
     std::filesystem::path blobPath = scriptSystem->HasScriptsBlob()
                                          ? scriptSystem->GetScriptsBlob()
                                          : App::Get()->GetPaths()->GetDefaultScriptBundleFile();
-    auto outputCacheFile = blobPath.replace_extension("redscripts.modded");
+    auto moddedCacheFile = blobPath.replace_extension("redscripts.modded");
 
     if (scriptSystem->HasScriptsBlob())
     {
@@ -104,7 +104,7 @@ bool ExecuteScc(SccApi& scc)
 
     if (settings.SupportsOutputCacheFileParameter())
     {
-        settings.SetOutputCacheFile(outputCacheFile);
+        settings.SetOutputCacheFile(moddedCacheFile);
     }
 
     for (const auto& [_, path] : scriptSystem->GetScriptPaths())
@@ -162,9 +162,9 @@ bool ExecuteScc(SccApi& scc)
 
     if (settings.SupportsOutputCacheFileParameter())
     {
-        scriptSystem->SetScriptsBlob(outputCacheFile);
-        engine->scriptsBlobPath = Utils::Narrow(outputCacheFile.c_str());
-        spdlog::info(L"script blob path was updated to '{}'", outputCacheFile);
+        scriptSystem->SetModdedScriptsBlob(moddedCacheFile);
+        engine->scriptsBlobPath = Utils::Narrow(moddedCacheFile.c_str());
+        spdlog::info(L"Scripts blob path was updated to '{}'", moddedCacheFile);
     }
 
     return true;

--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -92,9 +92,8 @@ bool ExecuteScc(SccApi& scc)
 
     ScriptCompilerSettings settings(scc, App::Get()->GetPaths()->GetR6Dir());
 
-    std::filesystem::path blobPath = scriptSystem->HasScriptsBlob()
-                                         ? scriptSystem->GetScriptsBlob()
-                                         : App::Get()->GetPaths()->GetDefaultScriptBundleFile();
+    std::filesystem::path blobPath = scriptSystem->HasScriptsBlob() ? scriptSystem->GetScriptsBlob()
+                                                                    : App::Get()->GetPaths()->GetDefaultScriptsBlob();
     auto moddedCacheFile = blobPath.replace_extension("redscripts.modded");
 
     if (scriptSystem->HasScriptsBlob())

--- a/src/dll/Hooks/LoadScripts.cpp
+++ b/src/dll/Hooks/LoadScripts.cpp
@@ -16,16 +16,12 @@ bool _CBaseEngine_LoadScripts(RED4ext::CBaseEngine* aEngine, const RED4ext::CStr
                               uint64_t a4)
 {
     auto scriptCompilationSystem = App::Get()->GetScriptCompilationSystem();
-    const auto& scriptsBlobPath = scriptCompilationSystem->GetScriptsBlob();
+    const auto& scriptsBlobPath =
+        scriptCompilationSystem->HasModdedScriptsBlob() ? scriptCompilationSystem->GetModdedScriptsBlob().string()
+        : scriptCompilationSystem->HasScriptsBlob()     ? scriptCompilationSystem->GetScriptsBlob().string()
+                                                        : aPath;
 
-    if (!scriptsBlobPath.empty())
-    {
-        return CBaseEngine_LoadScripts(aEngine, scriptsBlobPath.string(), aTimestamp, a4);
-    }
-    else
-    {
-        return CBaseEngine_LoadScripts(aEngine, aPath, aTimestamp, a4);
-    }
+    return CBaseEngine_LoadScripts(aEngine, scriptsBlobPath, aTimestamp, a4);
 }
 } // namespace
 

--- a/src/dll/Paths.cpp
+++ b/src/dll/Paths.cpp
@@ -58,6 +58,11 @@ std::filesystem::path Paths::GetR6Scripts() const
     return GetRootDir() / L"r6" / L"scripts";
 }
 
+std::filesystem::path Paths::GetDefaultScriptBundleFile() const
+{
+    return GetRootDir() / L"r6" / L"cache" / "final.redscripts";
+}
+
 std::filesystem::path Paths::GetR6CacheModded() const
 {
     return GetRootDir() / L"r6" / L"cache" / L"modded";

--- a/src/dll/Paths.cpp
+++ b/src/dll/Paths.cpp
@@ -58,7 +58,7 @@ std::filesystem::path Paths::GetR6Scripts() const
     return GetRootDir() / L"r6" / L"scripts";
 }
 
-std::filesystem::path Paths::GetDefaultScriptBundleFile() const
+std::filesystem::path Paths::GetDefaultScriptsBlob() const
 {
     return GetRootDir() / L"r6" / L"cache" / "final.redscripts";
 }

--- a/src/dll/Paths.hpp
+++ b/src/dll/Paths.hpp
@@ -17,6 +17,7 @@ public:
     std::filesystem::path GetRedscriptPathsFile() const;
 
     std::filesystem::path GetR6Scripts() const;
+    std::filesystem::path GetDefaultScriptBundleFile() const;
     std::filesystem::path GetR6CacheModded() const;
     std::filesystem::path GetR6Dir() const;
 

--- a/src/dll/Paths.hpp
+++ b/src/dll/Paths.hpp
@@ -17,7 +17,7 @@ public:
     std::filesystem::path GetRedscriptPathsFile() const;
 
     std::filesystem::path GetR6Scripts() const;
-    std::filesystem::path GetDefaultScriptBundleFile() const;
+    std::filesystem::path GetDefaultScriptsBlob() const;
     std::filesystem::path GetR6CacheModded() const;
     std::filesystem::path GetR6Dir() const;
 

--- a/src/dll/ScriptCompiler/ScriptCompilerSettings.cpp
+++ b/src/dll/ScriptCompiler/ScriptCompilerSettings.cpp
@@ -6,6 +6,12 @@ ScriptCompilerSettings::ScriptCompilerSettings(SccApi& aApi, std::filesystem::pa
 {
 }
 
+bool ScriptCompilerSettings::SupportsOutputCacheFileParameter() const
+{
+    // added in redscript 0.5.18, previous versions will have this set to NULL
+    return m_scc.settings_set_output_cache_file != nullptr;
+}
+
 ScriptCompilerSettings* ScriptCompilerSettings::AddScriptPath(std::filesystem::path aPath)
 {
     m_scriptPaths.emplace_back(aPath);
@@ -18,6 +24,12 @@ ScriptCompilerSettings* ScriptCompilerSettings::SetCustomCacheFile(std::filesyst
     return this;
 }
 
+ScriptCompilerSettings* ScriptCompilerSettings::SetOutputCacheFile(std::filesystem::path aPath)
+{
+    m_outputCacheFile = aPath;
+    return this;
+}
+
 ScriptCompilerSettings::Result ScriptCompilerSettings::Compile()
 {
     auto r6PathStr = m_r6Path.u8string();
@@ -27,6 +39,12 @@ ScriptCompilerSettings::Result ScriptCompilerSettings::Compile()
     {
         auto customCacheFileStr = m_customCacheFile.u8string();
         m_scc.settings_set_custom_cache_file(settings, reinterpret_cast<const char*>(customCacheFileStr.c_str()));
+    }
+
+    if (SupportsOutputCacheFileParameter() && !m_outputCacheFile.empty())
+    {
+        auto outputCacheFileStr = m_outputCacheFile.u8string();
+        m_scc.settings_set_output_cache_file(settings, reinterpret_cast<const char*>(outputCacheFileStr.c_str()));
     }
 
     for (const auto& path : m_scriptPaths)

--- a/src/dll/ScriptCompiler/ScriptCompilerSettings.hpp
+++ b/src/dll/ScriptCompiler/ScriptCompilerSettings.hpp
@@ -10,8 +10,11 @@ public:
 
     ScriptCompilerSettings(SccApi& aApi, std::filesystem::path aR6Path);
 
+    bool SupportsOutputCacheFileParameter() const;
+
     ScriptCompilerSettings* AddScriptPath(std::filesystem::path aPath);
     ScriptCompilerSettings* SetCustomCacheFile(std::filesystem::path aPath);
+    ScriptCompilerSettings* SetOutputCacheFile(std::filesystem::path aPath);
     Result Compile();
 
 private:
@@ -19,4 +22,5 @@ private:
     std::filesystem::path m_r6Path;
     std::vector<std::filesystem::path> m_scriptPaths;
     std::filesystem::path m_customCacheFile;
+    std::filesystem::path m_outputCacheFile;
 };

--- a/src/dll/Systems/ScriptCompilationSystem.cpp
+++ b/src/dll/Systems/ScriptCompilationSystem.cpp
@@ -42,6 +42,22 @@ bool ScriptCompilationSystem::HasScriptsBlob() const
     return m_hasScriptsBlob;
 }
 
+void ScriptCompilationSystem::SetModdedScriptsBlob(const std::filesystem::path& aPath)
+{
+    m_moddedScriptsBlobPath = aPath;
+    m_hasModdedScriptsBlob = true;
+}
+
+const std::filesystem::path& ScriptCompilationSystem::GetModdedScriptsBlob() const
+{
+    return m_moddedScriptsBlobPath;
+}
+
+bool ScriptCompilationSystem::HasModdedScriptsBlob() const
+{
+    return m_hasModdedScriptsBlob;
+}
+
 bool ScriptCompilationSystem::Add(std::shared_ptr<PluginBase> aPlugin, const wchar_t* aPath)
 {
     spdlog::trace(L"Adding path to script compilation: '{}'", aPath);

--- a/src/dll/Systems/ScriptCompilationSystem.hpp
+++ b/src/dll/Systems/ScriptCompilationSystem.hpp
@@ -32,6 +32,10 @@ public:
     const std::filesystem::path& GetScriptsBlob() const;
     bool HasScriptsBlob() const;
 
+    void SetModdedScriptsBlob(const std::filesystem::path& aPath);
+    const std::filesystem::path& GetModdedScriptsBlob() const;
+    bool HasModdedScriptsBlob() const;
+
     std::wstring GetCompilationArgs(const FixedWString& aOriginal);
     const Map_t& GetScriptPaths() const;
 
@@ -46,5 +50,7 @@ private:
     Map_t m_scriptPaths;
     bool m_hasScriptsBlob;
     std::filesystem::path m_scriptsBlobPath;
+    bool m_hasModdedScriptsBlob;
+    std::filesystem::path m_moddedScriptsBlobPath;
     SourceRefRepository m_sourceRefs;
 };


### PR DESCRIPTION
Basically:
- redscript now exposes a `scc_settings_set_output_cache_file` function, which configures the location where the compiled scripts will be written
- we invoke it with `[originalPathToScriptCache].modded` in order to write a separate file instead of overwriting the existing one
- after a successful compilation, we update both `ScriptCompilationSystem` and `GameEngine` with the path to the modded scripts file, so that any subsequent code that tries to load the file will be pointed at the correct path

The code was written to be compatible with old versions of redscript, I've tested it manually and it  worked fine. I've also tested this change against current 0.5.x branch in redscript with and without REDmod and both cases seem to work fine.

The code also supports multiple invocations - `ScriptCompilationSystem` handles the two paths separately. This is useful because RedHotTools can invoke the compiler multiple times during one game session.