### PR TITLE
fix: fix accidental blob path change

### DIFF
--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -92,9 +92,11 @@ bool ExecuteScc(SccApi& scc)
 
     ScriptCompilerSettings settings(scc, App::Get()->GetPaths()->GetR6Dir());
 
-    std::filesystem::path blobPath = scriptSystem->HasScriptsBlob() ? scriptSystem->GetScriptsBlob()
-                                                                    : App::Get()->GetPaths()->GetDefaultScriptsBlob();
-    auto moddedCacheFile = blobPath.replace_extension("redscripts.modded");
+    const auto blobPath = scriptSystem->HasScriptsBlob() ? scriptSystem->GetScriptsBlob()
+                                                         : App::Get()->GetPaths()->GetDefaultScriptsBlob();
+
+    auto moddedCacheFile = blobPath;
+    moddedCacheFile.replace_extension("redscripts.modded");
 
     if (scriptSystem->HasScriptsBlob())
     {


### PR DESCRIPTION
the `replace_extension` call was mutating `blobPath`, which was not intended,
this interestingly didn't cause any immediate problems except for the fact that the redmod scripts were being overwritten, so I didn't notice it in my test