### PR TITLE
Discover plugins first and load them after.

### DIFF
--- a/src/dll/Systems/PluginSystem.cpp
+++ b/src/dll/Systems/PluginSystem.cpp
@@ -71,7 +71,7 @@ void PluginSystem::Startup()
         return;
     }
 
-    std::vector<PluginEntry> plugins;
+    std::vector<PluginLoadInfo> pluginInfos;
 
     auto end = std::filesystem::end(iter);
     for (; iter != end; iter.increment(ec))
@@ -129,7 +129,7 @@ void PluginSystem::Startup()
 
             bool useAlteredSearchPath = depth == 1;
 
-            plugins.push_back({path, useAlteredSearchPath});
+            pluginInfos.push_back({path, useAlteredSearchPath});
         }
         else if (ec)
         {
@@ -139,9 +139,9 @@ void PluginSystem::Startup()
 
     // Load plugins after iterating with filesystem. Allow plugins to change their
     // directory's structure without breaking loading of other plugins.
-    for (const auto& plugin : plugins)
+    for (const auto& pluginInfo : pluginInfos)
     {
-        Load(plugin.path, plugin.useAlteredSearchPath);
+        Load(pluginInfo.path, pluginInfo.useAlteredSearchPath);
     }
 
     // In the case where the exe is hosted, check if the host exe has RED4Ext exports

--- a/src/dll/Systems/PluginSystem.cpp
+++ b/src/dll/Systems/PluginSystem.cpp
@@ -71,6 +71,8 @@ void PluginSystem::Startup()
         return;
     }
 
+    std::vector<PluginEntry> plugins;
+
     auto end = std::filesystem::end(iter);
     for (; iter != end; iter.increment(ec))
     {
@@ -126,12 +128,20 @@ void PluginSystem::Startup()
             }
 
             bool useAlteredSearchPath = depth == 1;
-            Load(path, useAlteredSearchPath);
+
+            plugins.push_back({path, useAlteredSearchPath});
         }
         else if (ec)
         {
             LOG_FS_ENTRY_ERROR(L"Could not check if the entry is a regular file", path, ec);
         }
+    }
+
+    // Load plugins after iterating with filesystem. Allow plugins to change their
+    // directory's structure without breaking loading of other plugins.
+    for (const auto& plugin : plugins)
+    {
+        Load(plugin.path, plugin.useAlteredSearchPath);
     }
 
     // In the case where the exe is hosted, check if the host exe has RED4Ext exports

--- a/src/dll/Systems/PluginSystem.hpp
+++ b/src/dll/Systems/PluginSystem.hpp
@@ -25,7 +25,7 @@ private:
     using Map_t = std::unordered_map<HMODULE, std::shared_ptr<PluginBase>>;
     using MapIter_t = Map_t::iterator;
 
-    struct PluginEntry
+    struct PluginLoadInfo
     {
         std::filesystem::path path;
         bool useAlteredSearchPath;

--- a/src/dll/Systems/PluginSystem.hpp
+++ b/src/dll/Systems/PluginSystem.hpp
@@ -25,6 +25,12 @@ private:
     using Map_t = std::unordered_map<HMODULE, std::shared_ptr<PluginBase>>;
     using MapIter_t = Map_t::iterator;
 
+    struct PluginEntry
+    {
+        std::filesystem::path path;
+        bool useAlteredSearchPath;
+    };
+
     void Load(const std::filesystem::path& aPath, bool aUseAlteredSearchPath);
     MapIter_t Unload(std::shared_ptr<PluginBase> aPlugin);
 


### PR DESCRIPTION
Loading a plugin while iterating through path of plugins can invalidate `recursive_directory_iterator`. It happens when a plugin change its directory's structure (remove operation). It stops and ignores loading of remaining plugins.

This will queue path of detected plugins, and only load them after.

Closes #63