### PR TITLE
Enable log rotation with timestamp context.

### DIFF
--- a/src/dll/App.cpp
+++ b/src/dll/App.cpp
@@ -149,6 +149,9 @@ void App::Startup()
         system->Startup();
     }
 
+    auto pluginNames = GetPluginSystem()->GetActivePlugins();
+    GetLoggerSystem()->RotateLogs(pluginNames);
+
     spdlog::info("RED4ext has been started");
 }
 

--- a/src/dll/Systems/LoggerSystem.cpp
+++ b/src/dll/Systems/LoggerSystem.cpp
@@ -34,7 +34,7 @@ void LoggerSystem::Shutdown()
     spdlog::trace("{} logger(s) flushed", count);
 }
 
-void LoggerSystem::RotateLogs(std::vector<std::wstring>& pluginNames) const
+void LoggerSystem::RotateLogs(std::vector<std::wstring> pluginNames) const
 {
     std::error_code error;
     auto files = std::filesystem::directory_iterator(m_paths.GetLogsDir(), error);

--- a/src/dll/Systems/LoggerSystem.cpp
+++ b/src/dll/Systems/LoggerSystem.cpp
@@ -1,5 +1,7 @@
-#include "stdafx.hpp"
 #include "LoggerSystem.hpp"
+#include "Config.hpp"
+#include "Paths.hpp"
+#include "stdafx.hpp"
 
 LoggerSystem::LoggerSystem(const Paths& aPaths, const Config& aConfig, const DevConsole& aDevConsole)
     : m_paths(aPaths)
@@ -30,6 +32,65 @@ void LoggerSystem::Shutdown()
 
     m_loggers.clear();
     spdlog::trace("{} logger(s) flushed", count);
+}
+
+void LoggerSystem::RotateLogs(std::vector<std::wstring>& pluginNames) const
+{
+    std::error_code error;
+    auto files = std::filesystem::directory_iterator(m_paths.GetLogsDir(), error);
+
+    if (error)
+    {
+        // Ignore and try the next time.
+        return;
+    }
+    spdlog::trace("Rotate logs...");
+    pluginNames.emplace_back(L"RED4ext");
+
+    // List all log files.
+    std::vector<std::filesystem::path> logs;
+
+    for (const std::filesystem::directory_entry& file : files)
+    {
+        const auto fileName = file.path().filename().wstring();
+
+        if (file.is_regular_file() && fileName.ends_with(L".log"))
+        {
+            logs.emplace_back(file.path());
+        }
+    }
+    const Config::LoggingConfig config = m_config.GetLogging();
+
+    // Rotate oldest logs per plugin.
+    for (auto pluginName : pluginNames)
+    {
+        Utils::ToLower(pluginName);
+        std::vector<std::filesystem::path> pluginLogs;
+
+        logs.erase(std::remove_if(logs.begin(), logs.end(),
+                                  [&pluginName, &pluginLogs](const auto& log)
+                                  {
+                                      if (log.filename().wstring().starts_with(pluginName))
+                                      {
+                                          pluginLogs.push_back(log);
+                                          return true;
+                                      }
+                                      return false;
+                                  }),
+                   logs.end());
+        std::sort(pluginLogs.begin(), pluginLogs.end(), [](const auto& a, const auto& b) { return a > b; });
+
+        // maxFiles is guaranteed to be >= 1.
+        for (size_t i = config.maxFiles; i < pluginLogs.size(); i++)
+        {
+            std::filesystem::remove(pluginLogs[i], error);
+        }
+    }
+    // Remove log files of removed plugins.
+    for (const auto& log : logs)
+    {
+        std::filesystem::remove(log, error);
+    }
 }
 
 void LoggerSystem::Trace(std::shared_ptr<PluginBase> aPlugin, std::string_view aText)

--- a/src/dll/Systems/LoggerSystem.cpp
+++ b/src/dll/Systems/LoggerSystem.cpp
@@ -64,7 +64,7 @@ void LoggerSystem::RotateLogs(std::vector<std::wstring> pluginNames) const
     // Rotate oldest logs per plugin.
     for (auto pluginName : pluginNames)
     {
-        Utils::ToLower(pluginName);
+        pluginName = Utils::ToLower(pluginName);
         std::vector<std::filesystem::path> pluginLogs;
 
         logs.erase(std::remove_if(logs.begin(), logs.end(),

--- a/src/dll/Systems/LoggerSystem.hpp
+++ b/src/dll/Systems/LoggerSystem.hpp
@@ -16,7 +16,7 @@ public:
     void Startup() final;
     void Shutdown() final;
 
-    void RotateLogs(std::vector<std::wstring>& plugins) const;
+    void RotateLogs(std::vector<std::wstring> plugins) const;
 
     void Trace(std::shared_ptr<PluginBase> aPlugin, std::string_view aText);
     void Trace(std::shared_ptr<PluginBase> aPlugin, std::wstring_view aText);

--- a/src/dll/Systems/LoggerSystem.hpp
+++ b/src/dll/Systems/LoggerSystem.hpp
@@ -16,6 +16,8 @@ public:
     void Startup() final;
     void Shutdown() final;
 
+    void RotateLogs(std::vector<std::wstring>& plugins) const;
+
     void Trace(std::shared_ptr<PluginBase> aPlugin, std::string_view aText);
     void Trace(std::shared_ptr<PluginBase> aPlugin, std::wstring_view aText);
 
@@ -60,14 +62,12 @@ private:
                 const auto stem = path.stem();
                 auto fileName = stem.wstring();
 
-                std::transform(fileName.begin(), fileName.end(), fileName.begin(),
-                               [](wchar_t aC) { return std::towlower(aC); });
+                Utils::ToLower(fileName);
 
                 const auto logName = aPlugin->GetName();
 
                 fileName = fmt::format(L"{}-{}.log", fileName, Utils::FormatCurrentTimestamp());
-                logger =
-                    Utils::CreateLogger(logName, fileName, m_paths, m_config, m_devConsole);
+                logger = Utils::CreateLogger(logName, fileName, m_paths, m_config, m_devConsole);
                 m_loggers.emplace(aPlugin, logger);
             }
         }

--- a/src/dll/Systems/LoggerSystem.hpp
+++ b/src/dll/Systems/LoggerSystem.hpp
@@ -62,7 +62,7 @@ private:
                 const auto stem = path.stem();
                 auto fileName = stem.wstring();
 
-                Utils::ToLower(fileName);
+                fileName = Utils::ToLower(fileName);
 
                 const auto logName = aPlugin->GetName();
 

--- a/src/dll/Systems/PluginSystem.cpp
+++ b/src/dll/Systems/PluginSystem.cpp
@@ -185,6 +185,18 @@ const std::vector<PluginSystem::PluginName>& PluginSystem::GetIncompatiblePlugin
     return m_incompatiblePlugins;
 }
 
+std::vector<PluginSystem::PluginName> PluginSystem::GetActivePlugins() const
+{
+    std::vector<PluginSystem::PluginName> plugins;
+
+    plugins.reserve(m_plugins.size());
+    for (const auto& [handle, plugin] : m_plugins)
+    {
+        plugins.emplace_back(plugin->GetName());
+    }
+    return plugins;
+}
+
 void PluginSystem::Load(const std::filesystem::path& aPath, bool aUseAlteredSearchPath)
 {
     spdlog::info(L"Loading plugin from '{}'...", aPath);

--- a/src/dll/Systems/PluginSystem.hpp
+++ b/src/dll/Systems/PluginSystem.hpp
@@ -20,6 +20,7 @@ public:
 
     std::shared_ptr<PluginBase> GetPlugin(HMODULE aModule) const;
     const std::vector<PluginName>& GetIncompatiblePlugins() const;
+    std::vector<PluginName> GetActivePlugins() const;
 
 private:
     using Map_t = std::unordered_map<HMODULE, std::shared_ptr<PluginBase>>;

--- a/src/dll/Utils.cpp
+++ b/src/dll/Utils.cpp
@@ -5,6 +5,7 @@
 #include "stdafx.hpp"
 
 #include <ctime>
+#include <cwctype>
 
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -229,4 +230,9 @@ std::wstring Utils::Widen(const std::string_view aText)
     }
 
     return result;
+}
+
+void Utils::ToLower(std::wstring& aText)
+{
+    std::transform(aText.begin(), aText.end(), aText.begin(), std::towlower);
 }

--- a/src/dll/Utils.cpp
+++ b/src/dll/Utils.cpp
@@ -232,7 +232,10 @@ std::wstring Utils::Widen(const std::string_view aText)
     return result;
 }
 
-void Utils::ToLower(std::wstring& aText)
+std::wstring Utils::ToLower(const std::wstring& acText)
 {
-    std::transform(aText.begin(), aText.end(), aText.begin(), std::towlower);
+    std::wstring text = acText;
+
+    std::transform(text.begin(), text.end(), text.begin(), std::towlower);
+    return text;
 }

--- a/src/dll/Utils.hpp
+++ b/src/dll/Utils.hpp
@@ -21,7 +21,7 @@ int32_t ShowMessageBox(const std::wstring_view aText, uint32_t aType = MB_OK);
 std::string Narrow(const std::wstring_view aText);
 std::wstring Widen(const std::string_view aText);
 
-void ToLower(std::wstring& aText);
+std::wstring ToLower(const std::wstring& acText);
 
 template<typename... Args>
 int32_t ShowMessageBox(uint32_t aType, const std::wstring_view aText, Args&&... aArgs)

--- a/src/dll/Utils.hpp
+++ b/src/dll/Utils.hpp
@@ -21,6 +21,8 @@ int32_t ShowMessageBox(const std::wstring_view aText, uint32_t aType = MB_OK);
 std::string Narrow(const std::wstring_view aText);
 std::wstring Widen(const std::string_view aText);
 
+void ToLower(std::wstring& aText);
+
 template<typename... Args>
 int32_t ShowMessageBox(uint32_t aType, const std::wstring_view aText, Args&&... aArgs)
 {


### PR DESCRIPTION
At startup, iterate over existing log files. Group them by plugin's name and sort them by timestamp. Remove X old files based on rotation's config, silently proceed if an IO operation fails.
Remove logs of uninstalled plugins too.

Add `PluginSystem::GetActivePlugins()` to list the name of installed plugins. Otherwise, `LoggerSystem` only list known loggers which is incomplete.
Add `Utils::ToLower(wstring)` to improve maintenance.

Log files to test it: [logs.zip](https://github.com/WopsS/RED4ext/files/15309165/red4ext-logs.zip)

Closes #59