### PR TITLE
Tiny refactor: All used address hashes now sit in their own file

### DIFF
--- a/src/dll/Detail/AddressHashes.hpp
+++ b/src/dll/Detail/AddressHashes.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+namespace Hashes
+{
+constexpr std::uint32_t AssertionFailed = 4285205681UL;
+
+constexpr std::uint32_t CBaseEngine_InitScripts = 2875532677UL;
+constexpr std::uint32_t CBaseEngine_LoadScripts = 3570081113UL;
+
+constexpr std::uint32_t CGameApplication_AddState = 4223801011UL;
+
+constexpr std::uint32_t GameInstance_CollectSaveableSystems = 3389547420UL;
+constexpr std::uint32_t Global_ExecuteProcess = 2203918127UL;
+constexpr std::uint32_t GsmState_SessionActive_ReportErrorCode = 2141394294UL;
+
+constexpr std::uint32_t IGameSystem_vtbl = 1854670959UL;
+constexpr std::uint32_t Main = 240386859UL;
+constexpr std::uint32_t ScriptValidator_Validate = 898639042UL;
+} // namespace Hashes

--- a/src/dll/Hooks/AssertionFailed.cpp
+++ b/src/dll/Hooks/AssertionFailed.cpp
@@ -1,6 +1,7 @@
 #include "AssertionFailed.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "stdafx.hpp"
 
@@ -11,7 +12,7 @@ bool isAttached = false;
 
 void _AssertionFailed(const char*, int, const char*, const char*, ...);
 
-Hook<decltype(&_AssertionFailed)> AssertionFailed_fnc(4285205681U, &_AssertionFailed);
+Hook<decltype(&_AssertionFailed)> AssertionFailed_fnc(Hashes::AssertionFailed, &_AssertionFailed);
 
 void _AssertionFailed(const char* aFile, int aLineNum, const char* aCondition, const char* aMessage, ...)
 {
@@ -69,7 +70,8 @@ bool Hooks::AssertionFailed::Detach()
         return false;
     }
 
-    spdlog::trace("Trying to detach the hook for the assertion failed function at {:#x}...", AssertionFailed_fnc.GetAddress());
+    spdlog::trace("Trying to detach the hook for the assertion failed function at {:#x}...",
+                  AssertionFailed_fnc.GetAddress());
 
     auto result = AssertionFailed_fnc.Detach();
     if (result != NO_ERROR)

--- a/src/dll/Hooks/CGameApplication.cpp
+++ b/src/dll/Hooks/CGameApplication.cpp
@@ -1,5 +1,6 @@
 #include "CGameApplication.hpp"
 #include "Addresses.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 
 #include "States/BaseInitializationState.hpp"
@@ -12,7 +13,8 @@ namespace
 bool isAttached = false;
 
 bool _CGameApplication_AddState(RED4ext::CGameApplication* aThis, RED4ext::IGameState* aState);
-Hook<decltype(&_CGameApplication_AddState)> CGameApplication_AddState(0xFBC216B3, &_CGameApplication_AddState);
+Hook<decltype(&_CGameApplication_AddState)> CGameApplication_AddState(Hashes::CGameApplication_AddState,
+                                                                      &_CGameApplication_AddState);
 
 bool _CGameApplication_AddState(RED4ext::CGameApplication* aThis, RED4ext::IGameState* aState)
 {

--- a/src/dll/Hooks/CollectSaveableSystems.cpp
+++ b/src/dll/Hooks/CollectSaveableSystems.cpp
@@ -1,5 +1,6 @@
 #include "CollectSaveableSystems.hpp"
 #include "Addresses.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "stdafx.hpp"
 
@@ -8,14 +9,15 @@ namespace
 bool isAttached = false;
 
 void _CollectSaveableSystems(void* a1, const RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>>& aAllSystems);
-Hook<decltype(&_CollectSaveableSystems)> GameInstance_CollectSaveableSystems(3389547420UL, &_CollectSaveableSystems);
+Hook<decltype(&_CollectSaveableSystems)> GameInstance_CollectSaveableSystems(
+    Hashes::GameInstance_CollectSaveableSystems, &_CollectSaveableSystems);
 
 void _CollectSaveableSystems(void* a1, const RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>>& aAllSystems)
 {
     static constexpr auto MaxSaveableSystems = 160;
     static constexpr auto PreSaveVFuncIndex = 0x130 / sizeof(uintptr_t);
 
-    static RED4ext::UniversalRelocPtr<uintptr_t> IGameSystemVFT(1854670959UL);
+    static RED4ext::UniversalRelocPtr<uintptr_t> IGameSystemVFT(Hashes::IGameSystem_vtbl);
     static uintptr_t DefaultPreSaveVFunc = IGameSystemVFT.GetAddr()[PreSaveVFuncIndex];
 
     RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>> saveableSystems;

--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -1,6 +1,7 @@
 #include "ExecuteProcess.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "ScriptCompiler/ScriptCompilerSettings.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
@@ -12,7 +13,7 @@ bool isAttached = false;
 
 bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
                             RED4ext::CString& aCurrentDirectory, char a5);
-Hook<decltype(&_Global_ExecuteProcess)> Global_ExecuteProcess(0x835D1F2F, &_Global_ExecuteProcess);
+Hook<decltype(&_Global_ExecuteProcess)> Global_ExecuteProcess(Hashes::Global_ExecuteProcess, &_Global_ExecuteProcess);
 
 bool _Global_ExecuteProcess(void* a1, RED4ext::CString& aCommand, FixedWString& aArgs,
                             RED4ext::CString& aCurrentDirectory, char a5)

--- a/src/dll/Hooks/InitScripts.cpp
+++ b/src/dll/Hooks/InitScripts.cpp
@@ -1,6 +1,7 @@
 #include "InitScripts.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
 
@@ -10,7 +11,8 @@ bool isAttached = false;
 
 void* _CBaseEngine_InitScripts(RED4ext::CBaseEngine* aThis, const RED4ext::CString& aScriptsBlobPath, int8_t a3,
                                int16_t a4);
-Hook<decltype(&_CBaseEngine_InitScripts)> CBaseEngine_InitScripts(0xAB652585, &_CBaseEngine_InitScripts);
+Hook<decltype(&_CBaseEngine_InitScripts)> CBaseEngine_InitScripts(Hashes::CBaseEngine_InitScripts,
+                                                                  &_CBaseEngine_InitScripts);
 
 void* _CBaseEngine_InitScripts(RED4ext::CBaseEngine* aThis, const RED4ext::CString& aScriptsBlobPath, int8_t a3,
                                int16_t a4)

--- a/src/dll/Hooks/LoadScripts.cpp
+++ b/src/dll/Hooks/LoadScripts.cpp
@@ -1,6 +1,7 @@
 #include "LoadScripts.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
 
@@ -10,7 +11,8 @@ bool isAttached = false;
 
 bool _CBaseEngine_LoadScripts(RED4ext::CBaseEngine* aEngine, const RED4ext::CString& aPath, uint64_t aTimestamp,
                               uint64_t a4);
-Hook<decltype(&_CBaseEngine_LoadScripts)> CBaseEngine_LoadScripts(0xD4CB1D59, &_CBaseEngine_LoadScripts);
+Hook<decltype(&_CBaseEngine_LoadScripts)> CBaseEngine_LoadScripts(Hashes::CBaseEngine_LoadScripts,
+                                                                  &_CBaseEngine_LoadScripts);
 
 bool _CBaseEngine_LoadScripts(RED4ext::CBaseEngine* aEngine, const RED4ext::CString& aPath, uint64_t aTimestamp,
                               uint64_t a4)

--- a/src/dll/Hooks/Main_Hooks.cpp
+++ b/src/dll/Hooks/Main_Hooks.cpp
@@ -1,6 +1,7 @@
 #include "Main_Hooks.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "stdafx.hpp"
 
@@ -9,7 +10,7 @@ namespace
 bool isAttached = false;
 
 int WINAPI _Main(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow);
-Hook<decltype(&_Main)> Main_fnc(240386859ul, &_Main);
+Hook<decltype(&_Main)> Main_fnc(Hashes::Main, &_Main);
 
 int WINAPI _Main(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
 {

--- a/src/dll/Hooks/ValidateScripts.cpp
+++ b/src/dll/Hooks/ValidateScripts.cpp
@@ -1,6 +1,7 @@
 #include "ValidateScripts.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "RED4ext/Scripting/ScriptReport.hpp"
 #include "Systems/ScriptCompilationSystem.hpp"
@@ -10,7 +11,8 @@ namespace
 bool isAttached = false;
 
 bool _ScriptValidator_Validate(uint64_t self, uint64_t a1, RED4ext::ScriptReport& aReport);
-Hook<decltype(&_ScriptValidator_Validate)> ScriptValidator_Validate(0x359024C2, &_ScriptValidator_Validate);
+Hook<decltype(&_ScriptValidator_Validate)> ScriptValidator_Validate(Hashes::ScriptValidator_Validate,
+                                                                    &_ScriptValidator_Validate);
 
 bool _ScriptValidator_Validate(uint64_t self, uint64_t a1, RED4ext::ScriptReport& aReport)
 {

--- a/src/dll/Hooks/gsmState_SessionActive.cpp
+++ b/src/dll/Hooks/gsmState_SessionActive.cpp
@@ -1,6 +1,7 @@
 #include "gsmState_SessionActive.hpp"
 #include "Addresses.hpp"
 #include "App.hpp"
+#include "Detail/AddressHashes.hpp"
 #include "Hook.hpp"
 #include "stdafx.hpp"
 
@@ -10,7 +11,7 @@ bool isAttached = false;
 
 void _GsmState_SessionActive_ReportErrorCode(uintptr_t);
 Hook<decltype(&_GsmState_SessionActive_ReportErrorCode)> GsmState_SessionActive_ReportErrorCode(
-    0x7FA31576, &_GsmState_SessionActive_ReportErrorCode);
+    Hashes::GsmState_SessionActive_ReportErrorCode, &_GsmState_SessionActive_ReportErrorCode);
 
 void _GsmState_SessionActive_ReportErrorCode(uintptr_t aThis)
 {


### PR DESCRIPTION
I wrote a tiny script a while back (https://github.com/alphanin9/CyberpunkReversing/blob/main/cp2077_check_core_framework_hashes.py) that can tell me what address hashes need to be updated. It'd have a hard time dealing with RED4ext DLL, as hashes are generally scattered across the whole project.
This should fix that and let me have more comprehensive coverage of what got screwed up by CDPR this time around.