### PR TITLE
fix: Update version of artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,13 @@ jobs:
           Copy-Item -Path ./${{ matrix.config }}/bin/RED4ext.pdb -Destination $packagingDir/red4ext
 
       - name: Upload ZIP
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: red4ext_${{ env.RED4EXT_PRETTY_CONFIG }}_${{ env.RED4EXT_COMMIT_SHA }}
           path: build/_packaging/
 
       - name: Upload ZIP (PDBs)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: red4ext_${{ env.RED4EXT_PRETTY_CONFIG }}_${{ env.RED4EXT_COMMIT_SHA }}_pdbs
           path: build/_packaging_pdbs/


### PR DESCRIPTION
Yeah apparently v3 is deprecated and causes CI builds on my end to fail
v4 seems to upload artifacts fine, so...
(maybe consider merging this a bit after 2.21 fix)