### PR TITLE
feat: never and mixed ref configuration

### DIFF
--- a/cmake/ConfigureAndIncludeRedscript.cmake
+++ b/cmake/ConfigureAndIncludeRedscript.cmake
@@ -1,6 +1,6 @@
 add_library(redscript INTERFACE)
 
-set(REDSCRIPT_SRC_DIR "${PROJECT_SOURCE_DIR}/deps/redscript/scc/lib/include")
+set(REDSCRIPT_SRC_DIR "${PROJECT_SOURCE_DIR}/deps/redscript/crates/scc/capi/include")
 set_target_properties(redscript PROPERTIES FOLDER "Dependencies")
 
 target_include_directories(redscript INTERFACE ${REDSCRIPT_SRC_DIR})

--- a/src/dll/Hooks/ExecuteProcess.cpp
+++ b/src/dll/Hooks/ExecuteProcess.cpp
@@ -114,6 +114,16 @@ bool ExecuteScc(SccApi& scc)
         settings.AddScriptPath(path);
     }
 
+    for (const auto& type : scriptSystem->GetNeverRefTypes())
+    {
+        settings.RegisterNeverRefType(type);
+    }
+
+    for (const auto& type : scriptSystem->GetMixedRefTypes())
+    {
+        settings.RegisterMixedRefType(type);
+    }
+
     const auto result = settings.Compile();
 
     if (const auto error = std::get_if<ScriptCompilerFailure>(&result))

--- a/src/dll/ScriptCompiler/ScriptCompilerSettings.cpp
+++ b/src/dll/ScriptCompiler/ScriptCompilerSettings.cpp
@@ -30,6 +30,18 @@ ScriptCompilerSettings* ScriptCompilerSettings::SetOutputCacheFile(std::filesyst
     return this;
 }
 
+ScriptCompilerSettings* ScriptCompilerSettings::RegisterNeverRefType(std::string aType)
+{
+    m_neverRefTypes.emplace_back(std::move(aType));
+    return this;
+}
+
+ScriptCompilerSettings* ScriptCompilerSettings::RegisterMixedRefType(std::string aType)
+{
+    m_mixedRefTypes.emplace_back(std::move(aType));
+    return this;
+}
+
 ScriptCompilerSettings::Result ScriptCompilerSettings::Compile()
 {
     auto r6PathStr = m_r6Path.u8string();
@@ -51,6 +63,28 @@ ScriptCompilerSettings::Result ScriptCompilerSettings::Compile()
     {
         auto pathStr = path.u8string();
         m_scc.settings_add_script_path(settings, reinterpret_cast<const char*>(pathStr.c_str()));
+    }
+
+    const auto registerNeverRefType = m_scc.settings_register_never_ref_type;
+    // Only configure never ref types when the compiler supports it.
+    if (registerNeverRefType)
+    {
+        for (const auto& type : m_neverRefTypes)
+        {
+            auto typeStr = type.c_str();
+            registerNeverRefType(settings, typeStr);
+        }
+    }
+
+    const auto registerMixedRefType = m_scc.settings_register_mixed_ref_type;
+    // Only configure mixed ref types when the compiler supports it.
+    if (registerMixedRefType)
+    {
+        for (const auto& type : m_mixedRefTypes)
+        {
+            auto typeStr = type.c_str();
+            registerMixedRefType(settings, typeStr);
+        }
     }
 
     auto result = m_scc.compile(settings);

--- a/src/dll/ScriptCompiler/ScriptCompilerSettings.hpp
+++ b/src/dll/ScriptCompiler/ScriptCompilerSettings.hpp
@@ -15,6 +15,8 @@ public:
     ScriptCompilerSettings* AddScriptPath(std::filesystem::path aPath);
     ScriptCompilerSettings* SetCustomCacheFile(std::filesystem::path aPath);
     ScriptCompilerSettings* SetOutputCacheFile(std::filesystem::path aPath);
+    ScriptCompilerSettings* RegisterNeverRefType(std::string aType);
+    ScriptCompilerSettings* RegisterMixedRefType(std::string aType);
     Result Compile();
 
 private:
@@ -23,4 +25,6 @@ private:
     std::vector<std::filesystem::path> m_scriptPaths;
     std::filesystem::path m_customCacheFile;
     std::filesystem::path m_outputCacheFile;
+    std::vector<std::string> m_neverRefTypes;
+    std::vector<std::string> m_mixedRefTypes;
 };

--- a/src/dll/Systems/ScriptCompilationSystem.cpp
+++ b/src/dll/Systems/ScriptCompilationSystem.cpp
@@ -59,6 +59,26 @@ bool ScriptCompilationSystem::HasModdedScriptsBlob() const
     return m_hasModdedScriptsBlob;
 }
 
+void ScriptCompilationSystem::RegisterNeverRefType(std::string aType)
+{
+    m_neverRefTypes.emplace_back(std::move(aType));
+}
+
+const std::vector<std::string>& ScriptCompilationSystem::GetNeverRefTypes() const
+{
+    return m_neverRefTypes;
+}
+
+void ScriptCompilationSystem::RegisterMixedRefType(std::string aType)
+{
+    m_mixedRefTypes.emplace_back(std::move(aType));
+}
+
+const std::vector<std::string>& ScriptCompilationSystem::GetMixedRefTypes() const
+{
+    return m_mixedRefTypes;
+}
+
 bool ScriptCompilationSystem::Add(std::shared_ptr<PluginBase> aPlugin, const wchar_t* aPath)
 {
     spdlog::trace(L"Adding path to script compilation: '{}'", aPath);

--- a/src/dll/Systems/ScriptCompilationSystem.hpp
+++ b/src/dll/Systems/ScriptCompilationSystem.hpp
@@ -36,6 +36,12 @@ public:
     const std::filesystem::path& GetModdedScriptsBlob() const;
     bool HasModdedScriptsBlob() const;
 
+    void RegisterNeverRefType(std::string aType);
+    const std::vector<std::string>& GetNeverRefTypes() const;
+
+    void RegisterMixedRefType(std::string aType);
+    const std::vector<std::string>& GetMixedRefTypes() const;
+
     std::wstring GetCompilationArgs(const FixedWString& aOriginal);
     const Map_t& GetScriptPaths() const;
 
@@ -53,4 +59,6 @@ private:
     bool m_hasModdedScriptsBlob;
     std::filesystem::path m_moddedScriptsBlobPath;
     SourceRefRepository m_sourceRefs;
+    std::vector<std::string> m_neverRefTypes;
+    std::vector<std::string> m_mixedRefTypes;
 };


### PR DESCRIPTION
Enables mods to configure types that are `mixedRef` and `neverRef` for redscript 1.0.

`mixedRef` types can be used with and without `w/ref`
`neverRef` types can only be used without `w/ref`